### PR TITLE
Hook keyevents into Minecraft's Keyboard loop

### DIFF
--- a/src/main/java/me/zero/client/api/event/defaults/game/core/KeyUpEvent.java
+++ b/src/main/java/me/zero/client/api/event/defaults/game/core/KeyUpEvent.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017 ZeroMemes
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.zero.client.api.event.defaults.game.core;
+
+/**
+ * Event called when a Key is released outside of a GUI while in-game
+ *
+ * @see ClickEvent
+ *
+ * @author Leaf
+ * @since 2.1
+ */
+public final class KeyUpEvent {
+
+    private final int key;
+
+    /**
+     * Creates a new instance of KeyUpEvent.
+     *
+     * @param key - The key code for the key that was released
+     */
+    public KeyUpEvent(int key) {
+        this.key = key;
+    }
+
+    /**
+     * @return The key code that corresponds to the released key
+     */
+    public final int getKey() {
+        return this.key;
+    }
+}

--- a/src/main/java/me/zero/client/api/event/handle/ClientHandler.java
+++ b/src/main/java/me/zero/client/api/event/handle/ClientHandler.java
@@ -21,10 +21,9 @@ import me.zero.alpine.listener.EventHandler;
 import me.zero.alpine.listener.Listener;
 import me.zero.client.api.event.defaults.filters.PacketFilter;
 import me.zero.alpine.type.EventPriority;
+import me.zero.client.api.event.defaults.game.core.*;
 import me.zero.client.api.event.defaults.game.misc.ChatEvent;
 import me.zero.client.api.event.defaults.game.network.PacketEvent;
-import me.zero.client.api.event.defaults.game.core.KeyEvent;
-import me.zero.client.api.event.defaults.game.core.ProfilerEvent;
 import me.zero.client.api.event.defaults.game.render.Render3DEvent;
 import me.zero.client.api.event.defaults.game.render.RenderHudEvent;
 import me.zero.client.api.util.interfaces.Helper;
@@ -67,6 +66,12 @@ public final class ClientHandler implements Helper {
         // Run onPres for all matching keybinds
         keybinds.forEach(Keybind::onPress);
     });
+
+    @EventHandler
+    private final Listener<KeyUpEvent> keyUpListener = new Listener<>(event ->
+            Keybind.getKeybinds().stream()
+                    .filter(bind -> bind.getKey() == event.getKey())
+                    .forEach(Keybind::onRelease));
 
     /**
      * Handles profiling events

--- a/src/main/java/me/zero/client/load/mixin/MixinMinecraft.java
+++ b/src/main/java/me/zero/client/load/mixin/MixinMinecraft.java
@@ -24,7 +24,6 @@ import me.zero.client.api.event.defaults.game.core.*;
 import me.zero.client.api.event.defaults.game.render.GuiEvent;
 import me.zero.client.api.event.defaults.game.world.WorldEvent;
 import me.zero.client.api.event.handle.ClientHandler;
-import me.zero.client.api.util.keybind.Keybind;
 import me.zero.client.api.util.render.gl.GlUtils;
 import me.zero.client.load.ClientInitException;
 import me.zero.client.load.mixin.wrapper.IMinecraft;
@@ -90,13 +89,7 @@ public abstract class MixinMinecraft implements IMinecraft {
         boolean down = Keyboard.getEventKeyState();
         int key = Keyboard.getEventKey();
 
-        if (down)
-            ClientAPI.EVENT_BUS.post(new KeyEvent(key));
-        else
-            // TODO: split into new KeyUp event
-            Keybind.getKeybinds().stream()
-                    .filter(bind -> bind.getKey() == key)
-                    .forEach(Keybind::onRelease);
+        ClientAPI.EVENT_BUS.post(down ? new KeyEvent(key) : new KeyUpEvent(key));
     }
 
     @Inject(method = "init", at = @At("RETURN"))


### PR DESCRIPTION
Instead of creating our own loop and keeping track of which keys were pressed, we should instead hook into Minecraft's existing `Keyboard.next()` loop `runKeyboardTick()`.

This both simplifies our code and allows `KeyEvent`s to take advantage of `Keyboard`'s event methods (e.g. `getEventKeyCharacter()`).

I also added `KeyUpEvent` in a second commit, which allows you to listen for key release events. This was required to keep `Keybind::onRelease` trigger logic within `ClientHandler` and out of `MixinMinecraft` (see how it was temporarily moved to the mixin in [`f04d5d0`](https://github.com/ZeroMemes/ClientAPI/commit/f04d5d00bf5057f1684d72874541032f6dccc175#diff-f5714072fa2e064ddc6a12c2e12daf4dR96)).