### PR TITLE
Open Chat when command prefix is typed

### DIFF
--- a/src/main/java/me/zero/client/api/command/handler/CommandHandler.java
+++ b/src/main/java/me/zero/client/api/command/handler/CommandHandler.java
@@ -24,8 +24,12 @@ import me.zero.client.api.command.exception.UnknownCommandException;
 import me.zero.client.api.command.exception.handler.ExceptionHandler;
 import me.zero.client.api.command.executor.CommandExecutor;
 import me.zero.client.api.command.executor.DirectExecutor;
+import me.zero.client.api.event.defaults.game.core.KeyEvent;
 import me.zero.client.api.event.defaults.internal.CommandExecutionEvent;
 import me.zero.client.api.manage.Manager;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiChat;
+import org.lwjgl.input.Keyboard;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -57,9 +61,9 @@ public final class CommandHandler {
 
     /**
      * Prefix used to indicate command input. The default
-     * prefix is "."
+     * prefix is .
      */
-    private String prefix = ".";
+    private char prefix = '.';
 
     public CommandHandler(Manager<Command> commandManager) {
         this.commandManager = commandManager;
@@ -78,6 +82,20 @@ public final class CommandHandler {
                 e.printStackTrace();
             else
                 handlers.forEach(handler -> handler.accept(e));
+        }
+    });
+
+    /**
+     * Handle key events
+     *
+     * Opens chat if the prefix is typed
+     *
+     * @since 2.2
+     */
+    @EventHandler
+    private final Listener<KeyEvent> keyEventListener = new Listener<>(event -> {
+        if (Keyboard.getEventCharacter() == this.getPrefix()) {
+            Minecraft.getMinecraft().displayGuiScreen(new GuiChat(String.valueOf(this.getPrefix())));
         }
     });
 
@@ -122,15 +140,33 @@ public final class CommandHandler {
 
     /**
      * Sets the chat command prefix
+     *
+     * @param prefix
+     *
+     * @since 2.2
      */
-    public final void setPrefix(String prefix) {
+    public final void setPrefix(char prefix) {
         this.prefix = prefix;
     }
 
     /**
-     * @return The chat command prefix
+     * Set the chat command prefix by using the first char of a string
+     *
+     * @param prefix
+     *
+     * @deprecated 2.2
      */
-    public final String getPrefix() {
-        return this.prefix;
+    @Deprecated
+    public final void setPrefix(String prefix) {
+        this.prefix = prefix.charAt(0);
+    }
+
+    /**
+     * @return The chat command prefix as a char
+     *
+     * @since 2.2
+     */
+    public final char getPrefix() {
+        return prefix;
     }
 }

--- a/src/main/java/me/zero/client/api/command/handler/listener/ChatCommandListener.java
+++ b/src/main/java/me/zero/client/api/command/handler/listener/ChatCommandListener.java
@@ -60,12 +60,12 @@ public final class ChatCommandListener extends CommandListener implements Helper
         }
 
         // If the message is a command
-        if (raw.startsWith(handler.getPrefix())) {
+        if (raw.charAt(0) == handler.getPrefix()) {
             // No matter what, always cancel the message if it starts with the command prefix
             event.cancel();
 
             // Removed the prefix from the message
-            raw = raw.substring(handler.getPrefix().length());
+            raw = raw.substring(1);
 
             // Create a matcher to parse the message
             Matcher matcher = REGEX.matcher(raw);


### PR DESCRIPTION
Based on an old commit so that it could be tested (the latest commits don't run because of breaking changes not updated in the example)

Adds a `KeyEvent` listener to `CommandHandler` which opens `GuiChat` if the prefix is typed. It also passes the prefix to `GuiChat` so that the  prefix doesn't need to be re-typed.

Command prefix is now a char to make it simpler to check when it is typed. A string may have been multiple characters, so you would either have to check the first char or check if each is entered in order.

This fixes ImpactDevelopment/ImpactClient#68

---

Changes to public API:
 - `CommandHandler.setPrefix(String)` is deprecated in favour of a new version accepting a `char`.
 - `CommandHandler.getPrefix()` now returns a `char` **(breaking)**.