### PR TITLE
Alternative #19 - Optionally open chat when command prefix is typed

### DIFF
--- a/src/main/java/me/zero/client/api/command/handler/CommandHandler.java
+++ b/src/main/java/me/zero/client/api/command/handler/CommandHandler.java
@@ -24,8 +24,12 @@ import me.zero.client.api.command.exception.UnknownCommandException;
 import me.zero.client.api.command.exception.handler.ExceptionHandler;
 import me.zero.client.api.command.executor.CommandExecutor;
 import me.zero.client.api.command.executor.DirectExecutor;
+import me.zero.client.api.event.defaults.game.core.KeyEvent;
 import me.zero.client.api.event.defaults.internal.CommandExecutionEvent;
 import me.zero.client.api.manage.Manager;
+import me.zero.client.api.util.interfaces.Helper;
+import net.minecraft.client.gui.GuiChat;
+import org.lwjgl.input.Keyboard;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -37,7 +41,7 @@ import java.util.stream.Collectors;
  * @author Brady
  * @since 6/1/2017 3:03 PM
  */
-public final class CommandHandler {
+public final class CommandHandler implements Helper {
 
     /**
      * Handlers to process command exceptions
@@ -61,9 +65,43 @@ public final class CommandHandler {
      */
     private String prefix = ".";
 
+    /**
+     * If true, CommandHandler will open chat whenever the first char
+     * of the prefix is typed.
+     */
+    private boolean openChat = false;
+
+    /**
+     * Construct a CommandHandler with some default options
+     *
+     * @param commandManager The command manager using this handler
+     * @param prefix The command prefix to use, or null to use the default
+     * @param openChat Whether or not the handler should open chat when
+     *                 prefix is typed
+     * @since 2.2
+     */
+    public CommandHandler(Manager<Command> commandManager, String prefix, boolean openChat) {
+        this(commandManager);
+
+        this.openChat = openChat;
+
+        if (prefix != null)
+            this.prefix = prefix;
+    }
+
     public CommandHandler(Manager<Command> commandManager) {
         this.commandManager = commandManager;
     }
+
+    @EventHandler
+    private final Listener<KeyEvent> keyEventListener = new Listener<>(event -> {
+        if (this.openChat) {
+            char typed = Keyboard.getEventCharacter();
+
+            if (this.prefix.charAt(0) == typed)
+                mc.displayGuiScreen(new GuiChat(String.valueOf(typed)));
+        }
+    });
 
     @EventHandler
     private final Listener<CommandExecutionEvent> commandExecutionListener = new Listener<>(event -> {
@@ -132,5 +170,27 @@ public final class CommandHandler {
      */
     public final String getPrefix() {
         return this.prefix;
+    }
+
+    /**
+     * If true, the handler will open chat whenever the first
+     * char of the prefix is typed.
+     *
+     * @param open Whether or not handler will open chat
+     * @since 2.2
+     */
+    public void openChatOnPrefix(boolean open) {
+        this.openChat = open;
+    }
+
+    /**
+     * If true, the handler will open chat whenever the first
+     * char of the prefix is typed.
+     *
+     * @return Whether or not handler will open chat
+     * @since 2.2
+     */
+    public boolean openChatOnPrefix() {
+        return this.openChat;
     }
 }


### PR DESCRIPTION
Alternative approach to #19, instead of refactoring prefix, we add an optional feature which checks if the first char of the prefix is typed.

Currently the option is disabled by default, but **I'm not convinced this is the right approach**. IMO it makes sense to be enabled by default. With the default prefix it always makes sense to open chat on prefix keyevent. If the prefix was changed it would be easy to also disable the chat opening at the same time, if desired. Even using the new added `CommandHandler` constructor.

I also added a constructor which sets values for `prefix` and `openChat`.

---

#### Option to open chat when command prefix is typed

Adds an option to open GuiChat when the first char in the command prefix
is typed. The chat will be populated with the typed char.

This is disabled by default because if the prefix has multiple chars, it
may lead to unintended behaviour (i.e. the chat being opened by accident).

- Adds a new constructor that sets prefix and openChat values
- Adds new getter/setter for openChat; openChatOnPrefix(boolean)
- Adds new KeyEvent listener which opens chat if openChat is true and
  the typed char matches prefix.charAt(0).