### PR TITLE
Add a flatten method to IValue

### DIFF
--- a/src/main/java/clientapi/value/IValue.java
+++ b/src/main/java/clientapi/value/IValue.java
@@ -21,6 +21,8 @@ import clientapi.util.interfaces.Identifiable;
 import clientapi.util.interfaces.Nameable;
 import clientapi.value.holder.IValueHolder;
 
+import java.util.stream.Stream;
+
 /**
  * Simple interface for Values
  *
@@ -45,4 +47,15 @@ public interface IValue<T> extends Nameable, Describable, Identifiable, IValueHo
      * @param value The new value
      */
     void setValue(T value);
+
+    /**
+     * Intended to be used with flatMap() to flatten the IValue tree recursively
+     * @param value the root node of the tree
+     * @return the flattened tree as a stream
+     */
+    static Stream<IValue> flatten(IValue value) {
+        return Stream.concat(
+                Stream.of(value),
+                value.getValues().stream().flatMap(IValue::flatten));
+    }
 }


### PR DESCRIPTION
See cmdset branch on private Impact gitlab for usage

Allows recursively flattening IValue tree from a root IValue node. Could probably be generalised to other tree-like structures too.

```java
// Example
List<IValue> values = module.getValues();
String search = "cool name here";

values.stream()
    .flatMap(IValue::flatten)
    .filter(value -> value.getName().equalsIgnoreCase(search))
    .findFirst().orElse(null);
```